### PR TITLE
fix: report the actual device type name for aliased types

### DIFF
--- a/src/server/actions.rs
+++ b/src/server/actions.rs
@@ -22,7 +22,10 @@ macro_rules! build_router {
         impl TapoDeviceType {
             pub fn type_name(&self) -> &'static str {
                 match self {
-                    $( Self::$device_name $(| Self::$alias_device_name)* => stringify!($device_name) ),+
+                    $(
+                        Self::$device_name => stringify!($device_name),
+                        $( Self::$alias_device_name => stringify!($alias_device_name), )*
+                    )+
                 }
             }
 


### PR DESCRIPTION
Hello, this is my first time contributing to a repo that is not mine, so please let me know if there are any issues with the PR!

When setting up tapo-rest I forgot to enable Third-Party Compatability in the app prior to launching my container. The error message displayed 

"! Failed to connect to device '4TapoP115': Failed to connect to **P110** plug '4TapoP115': Unauthorized: FORBIDDEN: Make sure Third-Party Compatibility is turned on in the Tapo app. If it's already enabled, try switching it off and then back on again. You can find this option by navigating to Me > Third-Party Services in the app"

Showing P110 instead of the actual device P115.

After this fix 

! Failed to connect to device '3TapoP115': Failed to connect to **P115** plug '3TapoP115': Unauthorized: FORBIDDEN: Make sure Third-Party Compatibility is turned on in the Tapo app. If it's already enabled, try switching it off and then back on again. You can find this option by navigating to Me > Third-Party Services in the app.

--------

`TapoDeviceType::type_name()` was generated with a single match arm per device group, so every alias collapsed onto the group's first name. A P115 reported itself as "P110", a P110M as "P110", an L535 as "L530", and so on -- making connection errors point at the wrong hardware, e.g. "Failed to connect to P110 plug '3TapoP115'".

Expand the macro to emit one arm per variant so each type stringifies its own name. `type_description()` stays grouped, since every member of a group genuinely shares the same description.

Only the error/label text is affected; device connections already used the correct per-type client handler.